### PR TITLE
Fix install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run compatible agents from the command line.
   ```
 - To locally install the `minion` executable, run:
   ```console
-  cargo install
+  cargo install --path .
   ```
   The binary `minion` gets installed to `~/.cargo/bin/minion`; make sure that this directory is in your `$PATH`.
 - Login to one of the supported LLM providers:


### PR DESCRIPTION
I changed the install command in the README.md from `cargo install` to `cargo install --path .`

Fixed Issue #1 