### PR TITLE
Delete container after usage

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -81,7 +81,6 @@ pub async fn run<P: AsRef<Path>>(
         }
     )?;
 
-    // Delete the container after its usage
     rt.delete_container(container_id.to_string()).await?;
 
     if task_outcome == TaskOutcome::Failure {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -67,7 +67,7 @@ pub async fn run<P: AsRef<Path>>(
     // Wait for the server to be ready by polling the /ready endpoint
     crate::api::wait_until_ready(&host_address).await?;
 
-    let (task_outcome, _) = tokio::try_join!(
+    let (task_outcome, container_id) = tokio::try_join!(
         async {
             server
                 .await
@@ -80,6 +80,11 @@ pub async fn run<P: AsRef<Path>>(
                 .map_err(|e| anyhow!(e))
         }
     )?;
+
+    // Delete the container after its usage
+    if let Some(container_id) = container_id {
+        rt.delete_container(container_id).await?;
+    }
 
     if task_outcome == TaskOutcome::Failure {
         return Ok(());

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -82,9 +82,7 @@ pub async fn run<P: AsRef<Path>>(
     )?;
 
     // Delete the container after its usage
-    if let Some(container_id) = container_id {
-        rt.delete_container(container_id).await?;
-    }
+    rt.delete_container(container_id.to_string()).await?;
 
     if task_outcome == TaskOutcome::Failure {
         return Ok(());

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -147,7 +147,7 @@ impl LocalDockerRuntime {
     }
 
     /// Run a container with the given configuration.
-    pub async fn run_container(&self, config: ContainerConfig) -> anyhow::Result<()> {
+    pub async fn run_container(&self, config: ContainerConfig) -> anyhow::Result<String> {
         let env: Vec<String> = config
             .env_vars
             .into_iter()
@@ -244,6 +244,13 @@ impl LocalDockerRuntime {
 
         let _ = output_forwarder.await;
 
+        // Return the container ID
+        Ok(container.id)
+    }
+
+    /// Delete a container by its ID.
+    pub async fn delete_container(&self, container_id: String) -> anyhow::Result<()> {
+        self.docker.remove_container(&container_id, None).await?;
         Ok(())
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -244,7 +244,6 @@ impl LocalDockerRuntime {
 
         let _ = output_forwarder.await;
 
-        // Return the container ID
         Ok(container.id)
     }
 


### PR DESCRIPTION
I implemented that the container gets deleted after usage.

For that I introduced with partial help from ORCA that run_container now returns the container id and the container gets then deleted after usage.

Closes #11 

Tested locally, `docker container prune` is now always empty.

Deleting the images might be the next problem! We have to keep that in mind.